### PR TITLE
Add support for min and max validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ class TestController < ActionController::Base
     p.param :user_ids, Array, of: Integer, default: [1, 2, 3]
     p.param :states, Array, of: String, default: ["active", "inactive"], reject_blank: true
     p.param :date_of_birth, Hash do |pp|
-      pp.param :gt, Date
+      pp.param :gt, Date, min: Date.new(2020, 1, 1), max: Date.new(2021, 1, 1)
       pp.param :lt, Date
     end
     p.param :created_at, Hash do |pp|
-      pp.param :lt, DateTime
+      pp.param :lt, DateTime, min: DateTime.new(2020, 1, 1), max: DateTime.new(2021, 1, 1)
       pp.param :gt, DateTime
     end
   end
@@ -55,7 +55,7 @@ If the parameters are valid, the controller action will be executed as normal. I
         {
             "message": "hired_on must be a valid Date"
         },
-      
+
     ]
 }
 ```
@@ -64,7 +64,7 @@ If the parameters are valid, the controller action will be executed as normal. I
 
 By default responses are returned in JSON format. To return responses as an empty HTML response, change the :format options in the validate_params methods to :html.
 
-Example: 
+Example:
 
 ```ruby
 validate_params :index, format: :html do |p|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,5 @@ en:
     required: "%{param} is required"
     invalid_type: "%{param} must be a valid %{type}"
     invalid_in: "%{param} is an invalid value"
+    more_than_max: "%{param} cannot be more than maximum"
+    less_than_min: "%{param} cannot be less than minimum"

--- a/lib/validate_params/param_validator.rb
+++ b/lib/validate_params/param_validator.rb
@@ -36,15 +36,27 @@ module ValidateParams
         end
 
         def date
-          return if Types::Date.valid?(@value)
+          if !Types::Date.valid?(@value)
+            @errors << { message: error_message }
+            return
+          end
 
-          @errors << { message: error_message }
+          formatted_value = Types::Date.cast(@value)
+
+          validate_min(formatted_value) if @options[:min].present?
+          validate_max(formatted_value) if @options[:max].present?
         end
 
         def date_time
-          return if Types::DateTime.valid?(@value)
+          if !Types::DateTime.valid?(@value)
+            @errors << { message: error_message }
+            return
+          end
 
-          @errors << { message: error_message }
+          formatted_value = Types::DateTime.cast(@value)
+
+          validate_min(formatted_value) if @options[:min].present?
+          validate_max(formatted_value) if @options[:max].present?
         end
 
         def integer
@@ -66,6 +78,24 @@ module ValidateParams
           @errors << {
             message: I18n.t("validate_params.invalid_in", param: error_param_name),
             valid_values: @options[:in]
+          }
+        end
+
+        def validate_min(value)
+          return if @options[:min] <= value
+
+          @errors << {
+            message: I18n.t("validate_params.less_than_min", param: error_param_name),
+            min: @options[:min]
+          }
+        end
+
+        def validate_max(value)
+          return if @options[:max] >= value
+
+          @errors << {
+            message: I18n.t("validate_params.more_than_max", param: error_param_name),
+            max: @options[:max]
           }
         end
 

--- a/spec/fixtures/controllers/with_min_and_max_controller.rb
+++ b/spec/fixtures/controllers/with_min_and_max_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "base_test_controller"
+
+class WithMinAndMaxController < BaseTestController
+  validate_params_for :index, format: :json do |p|
+    p.param :date_of_birth, Date, min: Date.new(2020, 1, 1), max: Date.new(2025, 1, 1)
+    p.param :created_at, DateTime, min: DateTime.new(2020, 1, 1, 12, 30), max: DateTime.new(2025, 1, 1, 12, 30)
+  end
+
+  def index
+    "success"
+  end
+end

--- a/spec/validate_params/validatable/with_min_and_max_usage_spec.rb
+++ b/spec/validate_params/validatable/with_min_and_max_usage_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "fixtures/controllers/with_min_and_max_controller"
+
+RSpec.describe ValidateParams::Validatable do
+  subject { ctrl.run_callbacks }
+
+  let(:date_of_birth) { "2022-01-01" }
+  let(:created_at) { "1683749410" }
+  let(:request_params) do
+    {
+      date_of_birth: date_of_birth,
+      created_at: created_at,
+    }
+  end
+
+  describe "before_actions" do
+    let(:ctrl) { WithMinAndMaxController.new(request_params) }
+
+    context "when created_at is less than minimum" do
+      let(:created_at) { "1577881799" }
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "created_at cannot be less than minimum")]
+          )
+        )
+      end
+    end
+
+    context "when created_at is more than maximum" do
+      let(:created_at) { "1735734601" }
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "created_at cannot be more than maximum")]
+          )
+        )
+      end
+    end
+
+    context "when created_at is not valid" do
+      let(:created_at) { "NOT VALID DATE" }
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "created_at must be a valid DateTime")]
+          )
+        )
+      end
+    end
+
+    context "when date_of_birth is less than minimum" do
+      let(:date_of_birth) { "2019-12-31" }
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "date_of_birth cannot be less than minimum")]
+          )
+        )
+      end
+    end
+
+    context "when date_of_birth is more than maximum" do
+      let(:date_of_birth) { "2026-12-31" }
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "date_of_birth cannot be more than maximum")]
+          )
+        )
+      end
+    end
+
+    context "when date_of_birth is invalid" do
+      let(:date_of_birth) { "NOT VALID DATE" }
+
+
+      it "render json error with localized message" do
+        expect(subject).to match hash_including(
+          json: hash_including(
+            success: false,
+            errors: [hash_including(message: "date_of_birth must be a valid Date")]
+          )
+        )
+      end
+    end
+
+    context "when all params are valid" do
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/validate_params/validatable/with_min_and_max_usage_spec.rb
+++ b/spec/validate_params/validatable/with_min_and_max_usage_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ValidateParams::Validatable do
   let(:request_params) do
     {
       date_of_birth: date_of_birth,
-      created_at: created_at,
+      created_at: created_at
     }
   end
 
@@ -84,7 +84,6 @@ RSpec.describe ValidateParams::Validatable do
 
     context "when date_of_birth is invalid" do
       let(:date_of_birth) { "NOT VALID DATE" }
-
 
       it "render json error with localized message" do
         expect(subject).to match hash_including(


### PR DESCRIPTION
For `Date` and `DateTime` only.

`min` and `max` passed should be valid type, incoming params from outside can be any type.
