### PR TITLE
[APP-733] Improved checking for empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## [0.13.1] - 2024-04-22
+
+- Improved checking for empty strings
+
 ## [0.13.0] - 2024-04-16
 
 - Added `:scrub_invalid_utf8` and `:scrub_invalid_utf8_replacement` options to String type to handle invalid UTF-8 characters
 - Added [configurator](README.md#configuration) to change default behaviour for certain options
-
 
 ## [0.12.5] - 2024-04-15
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    validate-params (0.13.0)
+    validate-params (0.13.1)
       activesupport (>= 6.1.0)
       i18n (>= 1.6)
 

--- a/lib/validate_params/configuration.rb
+++ b/lib/validate_params/configuration.rb
@@ -10,7 +10,7 @@ module ValidateParams
     def to_h
       {
         scrub_invalid_utf8: scrub_invalid_utf8,
-        scrub_invalid_utf8_replacement: scrub_invalid_utf8_replacement,
+        scrub_invalid_utf8_replacement: scrub_invalid_utf8_replacement
       }
     end
   end

--- a/lib/validate_params/param_validator.rb
+++ b/lib/validate_params/param_validator.rb
@@ -20,7 +20,7 @@ module ValidateParams
       end
 
       def call
-        return if @value.blank? && !@options[:required]
+        return if @value.nil? && !@options[:required]
 
         if @value.blank? && @options[:required]
           @errors << { message: required_error_message }

--- a/lib/validate_params/version.rb
+++ b/lib/validate_params/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ValidateParams
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end

--- a/spec/validate_params/validatable/default_usage_spec.rb
+++ b/spec/validate_params/validatable/default_usage_spec.rb
@@ -84,6 +84,17 @@ RSpec.describe ValidateParams::Validatable do
         it { is_expected.to be_nil }
       end
 
+      shared_examples "created_at must be a valid Hash" do
+        it "render json error with localized message" do
+          expect(subject).to match hash_including(
+            json: hash_including(
+              success: false,
+              errors: array_including(message: "created_at must be a valid Hash")
+            )
+          )
+        end
+      end
+
       context "when date param configured as hash and string is passed" do
         let(:request_params) do
           {
@@ -93,13 +104,12 @@ RSpec.describe ValidateParams::Validatable do
           }
         end
 
-        it "render json error with localized message" do
-          expect(subject).to match hash_including(
-            json: hash_including(
-              success: false,
-              errors: array_including(message: "created_at must be a valid Hash")
-            )
-          )
+        it_behaves_like "created_at must be a valid Hash"
+
+        context "when empty string is passed" do
+          let(:created_at) { "" }
+
+          it_behaves_like "created_at must be a valid Hash"
         end
       end
 

--- a/spec/validate_params/validatable/types/string_spec.rb
+++ b/spec/validate_params/validatable/types/string_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ValidateParams::Types::String do
   let(:raw_value) { "" }
-  let(:options) { Hash.new }
+  let(:options) { {} }
 
   subject { described_class.cast(raw_value, **options) }
 
@@ -17,7 +17,7 @@ RSpec.describe ValidateParams::Types::String do
 
     context "called without options" do
       let(:raw_value) { "Hello, \xFF \u0000 World!" }
-      let(:options) { Hash.new }
+      let(:options) { {} }
 
       it "returns the raw value" do
         expect(subject).to eq("Hello, \xFF \u0000 World!")

--- a/spec/validate_params/validatable/with_string_scrub_spec.rb
+++ b/spec/validate_params/validatable/with_string_scrub_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ValidateParams::Validatable do
         it "does not change input string" do
           expect {
             subject
-          }.to_not change { request_params[:without_scrub] }
+          }.to_not(change { request_params[:without_scrub] })
         end
       end
 
@@ -45,13 +45,13 @@ RSpec.describe ValidateParams::Validatable do
         it "does not change parameter with default" do
           expect {
             subject
-          }.to_not change { request_params[:default] }
+          }.to_not(change { request_params[:default] })
         end
 
         it "does not change parameter with disabled scrub" do
           expect {
             subject
-          }.to_not change { request_params[:without_scrub] }
+          }.to_not(change { request_params[:without_scrub] })
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe ValidateParams::Validatable do
         it "can be overridden by particular parameter" do
           expect {
             subject
-          }.to_not change { request_params[:without_scrub] }
+          }.to_not(change { request_params[:without_scrub] })
         end
       end
     end


### PR DESCRIPTION
Related to https://peopleforce.atlassian.net/browse/APP-733
Before these changes it was possible to bypass any data type checks by using an empty string.